### PR TITLE
Add crystal 0 18 0 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ license: MIT
 dependencies:
   active_record:
     github: waterlink/active_record.cr
-    version: 0.4.1
+    version: 0.4.2
   pg:
     github: will/crystal-pg
     version: 0.5.0

--- a/shard.yml
+++ b/shard.yml
@@ -12,4 +12,12 @@ dependencies:
     version: 0.4.2
   pg:
     github: will/crystal-pg
-    version: 0.5.0
+    version: 0.8.0
+
+development_dependencies:
+  mocks:
+    github: waterlink/mocks.cr
+    version: ~> 0.9
+  singleton:
+    github: waterlink/singleton.cr
+    version: ~> 0.1

--- a/src/postgres_adapter.cr
+++ b/src/postgres_adapter.cr
@@ -24,7 +24,7 @@ module PostgresAdapter
     @@primary_field : String?
     @@fields : Array(String)?
     @@register : Bool?
-    @@query_generators : Array(QueryGenerator)? #Array(ActiveRecord::QueryGenerator)?
+    @@query_generators : Array(QueryGenerator)?
     @connection : PG::Connection
 
     query_generator QueryGenerator.new


### PR DESCRIPTION
Not ready to be merged in, working on adding Crystal 0.18.x support but stuck with [this error](https://github.com/crystal-lang/crystal/issues/1408) here and not sure how to resolve it.

I added `singleton` and `mocks` as development dependencies as the "require" statements in the specs were failing without having the dependencies in this project.
