### PR TITLE
Updating active_record.cr and crystal-pg dependencies

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: postgres_adapter
-version: 0.4.1
+version: 0.4.2
 
 authors:
   - Oleksii Fedorov <waterlink000@gmail.com>
@@ -9,7 +9,7 @@ license: MIT
 dependencies:
   active_record:
     github: waterlink/active_record.cr
-    version: 0.4.1
+    version: ~> 0.4.3
   pg:
     github: will/crystal-pg
-    version: 0.5.0
+    version: ~> 0.8.0


### PR DESCRIPTION
With the fix I did in the [active_record.cr PR](https://github.com/waterlink/active_record.cr/pull/54), I hope this adapter works again.
