### PR TITLE
Enumerator fix

### DIFF
--- a/src/postgres_adapter.cr
+++ b/src/postgres_adapter.cr
@@ -45,7 +45,7 @@ module PostgresAdapter
 
     def create(fields)
       field_names = self.fields.select { |x| x != primary_field }
-      field_refs = (1...self.fields.size).map { |x| "$#{x}" }
+      field_refs = (1..self.fields.size).map { |x| "$#{x}" }
 
       query = "INSERT INTO #{table_name} (#{field_names.join(", ")}) VALUES (#{field_refs.join(", ")}) RETURNING #{primary_field}"
 


### PR DESCRIPTION
This was causing the sql insert queries to have 1 less attribute, for instance 
`INSERT into users (name, email password) VALUES ( $1, $2 ) RETURNING id`